### PR TITLE
Update ok.py

### DIFF
--- a/pykrige/ok.py
+++ b/pykrige/ok.py
@@ -658,7 +658,8 @@ class OrdinaryKriging:
             b[zero_index[0], zero_index[1], 0] = 0.0
         b[:, n, 0] = 1.0
 
-        if (~mask).any():
+        # if (~mask).any():
+        if (mask).any():
             mask_b = np.repeat(mask[:, np.newaxis, np.newaxis], n + 1, axis=1)
             b = np.ma.array(b, mask=mask_b)
 


### PR DESCRIPTION
According to the documentation and logic of execute() function a mask should only be applied when selected style is 'masked'. In case of 'points' style, an unmasked array should be returned.